### PR TITLE
modified scaling factors

### DIFF
--- a/source/backgrounds/sphericalbackground.py
+++ b/source/backgrounds/sphericalbackground.py
@@ -24,6 +24,7 @@ class FlatSphericalBackground:
         self.d1_scaling_vector = self.get_d1_scaling_vector()
         self.d1_inverse_scaling_vector = self.get_d1_inverse_scaling_vector()        
         self.d2_scaling_vector = self.get_d2_scaling_vector()
+        self.d2_inverse_scaling_vector = self.get_d2_inverse_scaling_vector()        
         self.scaling_matrix = self.get_scaling_matrix()
         self.inverse_scaling_matrix = self.get_inverse_scaling_matrix()
         self.d1_scaling_matrix = self.get_d1_scaling_matrix()
@@ -80,6 +81,17 @@ class FlatSphericalBackground:
         
         return ds_dx
     
+    def get_d2_inverse_scaling_vector(self) :
+    
+        d2s_dxdy = np.zeros([self.N, SPACEDIM, SPACEDIM, SPACEDIM])
+        d2s_dxdy[:,i_t, i_r, i_r] += 2.0 / (self.r ** 3.0) 
+        d2s_dxdy[:,i_p, i_r, i_r] += 2.0 / (self.r ** 3.0) / sintheta
+        d2s_dxdy[:,i_p, i_r, i_t] += 1.0 / (self.r ** 2.0 * sintheta ** 2.0) * costheta
+        d2s_dxdy[:,i_p, i_t, i_r] += 1.0 / (self.r ** 2.0 * sintheta ** 2.0) * costheta
+        d2s_dxdy[:,i_p, i_t, i_t] += 1.0 / (self.r * sintheta ** 3.0) * (costheta ** 2.0 + 1.0)
+        
+        return d2s_dxdy
+
     # This is d2 (scaling_i) / dx^j dx^k
     def get_d2_scaling_vector(self) :
         

--- a/source/bssn/bssnrhs.py
+++ b/source/bssn/bssnrhs.py
@@ -24,18 +24,18 @@ def get_bssn_rhs(bssn_rhs, r, bssn_vars, d1, d2, background, emtensor) :
 
 
    # rescaled shift in terms of scaling factors and bssn_vars.shift_U
-    r_shift_U = background.inverse_scaling_vector * bssn_vars.shift_U
-    r_d1_shift_U = (background.d1_inverse_scaling_vector * bssn_vars.shift_U[:,:,np.newaxis] 
+    Shift_U = background.inverse_scaling_vector * bssn_vars.shift_U
+    d1_Shift_U = (background.d1_inverse_scaling_vector * bssn_vars.shift_U[:,:,np.newaxis] 
                      + d1.shift_U * background.inverse_scaling_vector[:,:,np.newaxis])
-    r_d2_shift_U = (np.einsum('xijk,xi->xijk', background.d2_inverse_scaling_vector, bssn_vars.shift_U)
+    d2_Shift_U = (np.einsum('xijk,xi->xijk', background.d2_inverse_scaling_vector, bssn_vars.shift_U)
          + np.einsum('xik,xij->xijk', background.d1_inverse_scaling_vector, d1.shift_U)
          + np.einsum('xij,xik->xijk', background.d1_inverse_scaling_vector, d1.shift_U)
          + np.einsum('xi,xijk->xijk', background.inverse_scaling_vector, d2.shift_U)
     )
 
     # This is the conformal divergence of the shift \bar D_i \beta^i
-    bar_div_shift =  np.einsum('xii->x', r_d1_shift_U)
-    bar_div_shift += np.einsum('xiij,xj->x', bar_chris, r_shift_U)     
+    bar_div_shift =  np.einsum('xii->x', d1_Shift_U)
+    bar_div_shift += np.einsum('xiij,xj->x', bar_chris, Shift_U)     
 
     # Trace of \bar Aij and A_ij A^ij
     trace_bar_A   = get_trace_bar_A(r, bssn_vars, background)       
@@ -60,8 +60,8 @@ def get_bssn_rhs(bssn_rhs, r, bssn_vars, d1, d2, background, emtensor) :
     # This is \hat\gamma_jk \hat D_i shift^k 
     # (note Etienne paper notation ambiguity - this is NOT \hat D_i \beta_j)
     hat_D_shift_U = (
-         np.einsum('xjk,xki->xij', background.hat_gamma_LL, r_d1_shift_U)
-         + np.einsum('xjk,xkil,xl->xij', background.hat_gamma_LL, background.hat_christoffel, r_shift_U)
+         np.einsum('xjk,xki->xij', background.hat_gamma_LL, d1_Shift_U)
+         + np.einsum('xjk,xkil,xl->xij', background.hat_gamma_LL, background.hat_christoffel, Shift_U)
    )
     
     # Rescale quantities because we want change in h not epsilon
@@ -140,26 +140,26 @@ def get_bssn_rhs(bssn_rhs, r, bssn_vars, d1, d2, background, emtensor) :
     # Where \Delta^k = \bar\gamma^ij (\bar\Gamma^k_ij - \hat\Gamma^k_ij)  
 
     # \bar \gamma^jk \hat D_j \hat D_k shift^i
-    hat_D2_shift = (  np.einsum('xjk,xijk->xi', bar_gamma_UU, r_d2_shift_U)
-                + np.einsum('xjk,xikl,xlj->xi', bar_gamma_UU, background.hat_christoffel, r_d1_shift_U)
-                + np.einsum('xjk,xijl,xlk->xi', bar_gamma_UU, background.hat_christoffel, r_d1_shift_U)
-                - np.einsum('xjk,xljk,xil->xi', bar_gamma_UU, background.hat_christoffel, r_d1_shift_U)
-                + np.einsum('xjk,xiklj,xl->xi', bar_gamma_UU, background.d1_hat_christoffel, r_shift_U)
+    hat_D2_shift = (  np.einsum('xjk,xijk->xi', bar_gamma_UU, d2_Shift_U)
+                + np.einsum('xjk,xikl,xlj->xi', bar_gamma_UU, background.hat_christoffel, d1_Shift_U)
+                + np.einsum('xjk,xijl,xlk->xi', bar_gamma_UU, background.hat_christoffel, d1_Shift_U)
+                - np.einsum('xjk,xljk,xil->xi', bar_gamma_UU, background.hat_christoffel, d1_Shift_U)
+                + np.einsum('xjk,xiklj,xl->xi', bar_gamma_UU, background.d1_hat_christoffel, Shift_U)
                 + np.einsum('xjk,xijl,xlkm,xm->xi', bar_gamma_UU, background.hat_christoffel, 
-                                                    background.hat_christoffel, r_shift_U)
+                                                    background.hat_christoffel, Shift_U)
                 - np.einsum('xjk,xljk,xilm,xm->xi', bar_gamma_UU, background.hat_christoffel, 
-                                                    background.hat_christoffel, r_shift_U))
+                                                    background.hat_christoffel, Shift_U))
     # This is \bar D^i (\bar D_j \beta^j) note the raised index of j
     # We can use that D_i V^i = 1/sqrt(detgamma) d_i [sqrt(detgamma) V^i]
     # And that we impose det(bargamma) = det(hatgamma) which we know the derivs for analytically
-    bar_D_div_shift = (np.einsum('xij,xkjk->xi', bar_gamma_UU, r_d2_shift_U)
+    bar_D_div_shift = (np.einsum('xij,xkjk->xi', bar_gamma_UU, d2_Shift_U)
                      + (0.5 / background.det_hat_gamma[:,np.newaxis] * 
-                        np.einsum('xij,xkj,xk->xi', bar_gamma_UU, r_d1_shift_U, background.d1_det_hat_gamma))
+                        np.einsum('xij,xkj,xk->xi', bar_gamma_UU, d1_Shift_U, background.d1_det_hat_gamma))
                      + (0.5 / background.det_hat_gamma[:,np.newaxis] * 
-                        np.einsum('xij,xjk,xk->xi', bar_gamma_UU, background.d2_det_hat_gamma, r_shift_U))
+                        np.einsum('xij,xjk,xk->xi', bar_gamma_UU, background.d2_det_hat_gamma, Shift_U))
                      - (0.5 / background.det_hat_gamma[:,np.newaxis] / background.det_hat_gamma[:,np.newaxis] 
                         * np.einsum('xij,xj,xk,xk->xi', bar_gamma_UU, background.d1_det_hat_gamma, 
-                                                        background.d1_det_hat_gamma, r_shift_U)))
+                                                        background.d1_det_hat_gamma, Shift_U)))
 
     # Calculate rhs
     dlambdadt = (hat_D2_shift 

--- a/source/bssn/tensoralgebra.py
+++ b/source/bssn/tensoralgebra.py
@@ -135,8 +135,8 @@ def get_tensor_advection(r, A_LL, advec_A_LL, shift_U, d1_shift_U, background) :
     advec_A_LL = ( np.einsum('xijk,xk->xij', advec_A_LL, background.inverse_scaling_vector * shift_U)
                  + np.einsum('xijk,xk->xij', background.inverse_scaling_matrix[:,:,:,np.newaxis] * A_LL[:,:,:,np.newaxis] 
                                              * background.d1_scaling_matrix, background.inverse_scaling_vector * shift_U)
-                 + np.einsum('xik,xkj->xij', A_LL, background.scaling_vector[:,np.newaxis,:] * d1_shift_U) 
-                 + np.einsum('xjk,xki->xij', A_LL, background.scaling_vector[:,np.newaxis,:] * d1_shift_U)                   
+                 + np.einsum('xik,xkj->xij', A_LL, background.inverse_scaling_vector[:,np.newaxis,:] * d1_shift_U) 
+                 + np.einsum('xjk,xki->xij', A_LL, background.inverse_scaling_vector[:,np.newaxis,:] * d1_shift_U)                   
                  + np.einsum('xik,xjk->xij', A_LL * background.scaling_vector[:,np.newaxis,:], 
                                              background.inverse_scaling_vector[:,:,np.newaxis] * shift_U[:,np.newaxis,:] 
                                              * background.d1_inverse_scaling_vector) 

--- a/source/core/rhsevolution.py
+++ b/source/core/rhsevolution.py
@@ -67,8 +67,8 @@ def get_rhs(t_i, current_state: np.ndarray, grid: Grid, background, matter, prog
 
     # Now enforce it
     bar_gamma_LL = get_bar_gamma_LL(r, bssn_vars.h_LL, background)
-    bssn_vars.h_LL = (rescaling_factor[:,np.newaxis,np.newaxis] * 
-                        (bar_gamma_LL - background.hat_gamma_LL) * background.inverse_scaling_matrix)
+    new_bar_gamma_LL = rescaling_factor[:,np.newaxis,np.newaxis] * bar_gamma_LL
+    bssn_vars.h_LL = (new_bar_gamma_LL - background.hat_gamma_LL) * background.inverse_scaling_matrix
         
     # Also limit the conformal factor so it doesn't blow up near BHs
     bssn_vars.phi = np.minimum(bssn_vars.phi, np.ones(N)*1.0e6)


### PR DESCRIPTION
- corrected scaling factors in tensor advection calculation
- in bssnrhs.py, replaced bssn_vars.shift_U, d1.shift_U, and d2.shift_U with scaling factor corrected version r_shift_U, r_d1_shift_U, and r_d2_shift_U. 
- Double-checked scaling factor consistency related to bar_A_LL. No changes are made.

These changes should make the scaling factors consistent, i.e., all evolution variables are scaled versions of the bssn variables.

The updated code has passed the Kerr BH test. The scalar evolution solutions also remain unchanged. Note that these are weak tests since the scaling factor related to shift_r is simply 1.0. A non-spherically-symmetric test or a non-flat background is needed for more rigorous checks. 